### PR TITLE
Implementation of EventSelector tool

### DIFF
--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -29,19 +29,13 @@ bool DigitBuilder::Initialise(std::string configfile, DataModel &data){
   /// Get the Tool configuration variables
 	m_variables.Get("verbosity",verbosity);
 	m_variables.Get("PhotoDetectorConfiguration", fPhotodetectorConfiguration);
-	m_variables.Get("MRDRecoCut", fMRDRecoCut);
-	m_variables.Get("MCTruthCut", fMCTruthCut);
 	
 	/// Construct the other objects we'll be setting at event level,
-	fMuonStartVertex = new RecoVertex();
-	fMuonStopVertex = new RecoVertex();
 	fDigitList = new std::vector<RecoDigit>;
 		
 	// Make the RecoDigit Store if it doesn't exist
 	int recoeventexists = m_data->Stores.count("RecoEvent");
 	if(recoeventexists==0) m_data->Stores["RecoEvent"] = new BoostStore(false,2);
-	fEventCutStatus = false;
-	m_data->Stores.at("RecoEvent")->Set("EventCutStatus", fEventCutStatus); 
   return true;
 }
 
@@ -57,7 +51,12 @@ bool DigitBuilder::Execute(){
 		Log("DigitBuilder Tool: No ANNIEEvent store!",v_error,verbosity); 
 		return false;
 	};
-	
+	// see if "RecoEvent" exists
+ 	auto get_recoevent = m_data->Stores.count("RecoEvent");
+ 	if(!get_recoevent){
+  		Log("EventSelector Tool: No RecoEvent store!",v_error,verbosity); 
+  		return false;
+	};
 	/// First, see if this is a delayed trigger in the event
 	auto get_mctrigger = m_data->Stores.at("ANNIEEvent")->Get("MCTriggernum",fMCTriggernum);
 	if(!get_mctrigger){ 
@@ -88,40 +87,18 @@ bool DigitBuilder::Execute(){
 		return false;
 	}
 	
-	// Retrieve particle information from ANNIEEvent
-  auto get_mcparticles = m_data->Stores.at("ANNIEEvent")->Get("MCParticles",fMCParticles);
-	if(!get_mcparticles){ 
-		Log("DigitBuilder:: Tool: Error retrieving MCParticles from ANNIEEvent!",v_error,verbosity); 
-		return false; 
-	}
-	
-	/// check if "MRDTracks" store exists
-	int mrdtrackexists = m_data->Stores.count("MRDTracks");
-	if(mrdtrackexists == 0) {
-	  Log("DigitBuilder Tool: MRDTracks store doesn't exist!",v_message,verbosity);
-	  return false;
-	} 	
-	
-	/// Find true neutrino vertex which is defined by the start point of the Primary muon
-  this->FindTrueVertexFromMC();
-	
-	// Select event by MRD Reconstruction information
-	if(fMRDRecoCut) {
-	  bool passMRD = this->EventSelectionByMRDReco();
-	  if(!passMRD) {
-	      Log("DigitBuilder Tool: Event doesn't pass data selection using MRD reconstruction information",v_message,verbosity);
+        auto get_evtcutstatus = m_data->Stores.at("RecoEvent")->Get("EventCutStatus",fEventCutStatus);
+	if(!get_evtcutstatus){
+		Log("DigitBuilder Tool: Error retrieving EventCutStatus from RecoEvent!", v_error,verbosity);
+		return false;
+
+	// Check if event passed all cuts checked with EventSelector
+	if(!fEventCutStatus){
+              std::cout << "Message: Event does not pass all event cuts from EventSelector" << std::endl;
+	      Log("DigitBuilder Tool: Event doesn't pass all event cuts from EventSelector",v_message,verbosity);
 	      return true;
 	  }
   } 
-	
-	// Select event by fiducial volume with MC trueth information
-	 if(fMCTruthCut) {
-	   bool passMCcut = this->EventSelectionByMCTruthInfo();
-	   if(!passMCcut) {
-	   	 Log("DigitBuilder Tool: Event doesn't pass data selection using MC information",v_message,verbosity);
-	     return true;
-	   }
-	 }
 	 
 	// Build RecoDigit
 	this->BuildRecoDigit();
@@ -131,13 +108,6 @@ bool DigitBuilder::Execute(){
 		return true;
 	}
 	
-	// event passed selection
-	fEventCutStatus = true;
-	m_data->Stores.at("RecoEvent")->Set("EventCutStatus", fEventCutStatus);
-	
-	// Push true vertex to RecoEvent store
-  this->PushTrueVertex(true);
-
 	// Push recodigits to RecoEvent
 	this->PushRecoDigits(true); 
 	
@@ -145,8 +115,6 @@ bool DigitBuilder::Execute(){
 }
 
 bool DigitBuilder::Finalise(){
-	delete fMuonStartVertex; fMuonStartVertex = 0;
-	delete fMuonStopVertex; fMuonStopVertex = 0;
 	delete fDigitList; fDigitList = 0;
 	if(verbosity>0) cout<<"DigitBuilder exitting"<<endl;
   return true;
@@ -286,154 +254,5 @@ void DigitBuilder::PushRecoDigits(bool savetodisk) {
 
 void DigitBuilder::Reset() {
 	// Reset 
-	fMuonStartVertex->Reset();
-	fMuonStopVertex->Reset();
   fDigitList->clear();
-  fEventCutStatus = false;
-  m_data->Stores.at("RecoEvent")->Set("EventCutStatus", fEventCutStatus); 
-}
-
-RecoVertex* DigitBuilder::FindTrueVertexFromMC() {
-	
-	// loop over the MCParticles to find the highest enery primary muon
-	// MCParticles is a std::vector<MCParticle>
-	MCParticle primarymuon;  // primary muon
-	bool mufound=false;
-	if(fMCParticles){
-		Log("DigitBuilder::  Tool: Num MCParticles = "+to_string(fMCParticles->size()),v_message,verbosity);
-		for(int particlei=0; particlei<fMCParticles->size(); particlei++){
-			MCParticle aparticle = fMCParticles->at(particlei);
-			//if(v_debug<verbosity) aparticle.Print();       // print if we're being *really* verbose
-			if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle
-			if(aparticle.GetPdgCode()!=13) continue;       // not a muon
-			primarymuon = aparticle;                       // note the particle
-			mufound=true;                                  // note that we found it
-			//primarymuon.Print();
-			break;                                         // won't have more than one primary muon
-		}
-	} else {
-		Log("DigitBuilder::  Tool: No MCParticles in the event!",v_error,verbosity);
-	}
-	if(not mufound){
-		Log("DigitBuilder::  Tool: No muon in this event",v_warning,verbosity);
-		return 0;
-	}
-	
-	// retrieve desired information from the particle
-	Position muonstartpos = primarymuon.GetStartVertex();    // only true if the muon is primary
-	double muonstarttime = primarymuon.GetStartTime().GetNs() + primarymuon.GetStopTime().GetTpsec()/1000;
-	Position muonstoppos = primarymuon.GetStopVertex();    // only true if the muon is primary
-	double muonstoptime = primarymuon.GetStopTime().GetNs() + primarymuon.GetStopTime().GetTpsec()/1000;
-	
-	Direction muondirection = primarymuon.GetStartDirection();
-	double muonenergy = primarymuon.GetStartEnergy();
-	// set true vertex
-	// change unit
-	muonstartpos.UnitToCentimeter(); // convert unit from meter to centimeter
-	muonstoppos.UnitToCentimeter(); // convert unit from meter to centimeter
-	// change coordinate for muon start vertex
-	muonstartpos.SetY(muonstartpos.Y()+14.46469);
-	muonstartpos.SetZ(muonstartpos.Z()-168.1);
-	fMuonStartVertex->SetVertex(muonstartpos, muonstarttime);
-  fMuonStartVertex->SetDirection(muondirection);
-  //  charge coordinate for muon stop vertex
-  muonstoppos.SetY(muonstoppos.Y()+14.46469);
-	muonstoppos.SetZ(muonstoppos.Z()-168.1);
-	fMuonStopVertex->SetVertex(muonstoppos, muonstoptime); 
-  
-  logmessage = "  trueVtx=(" +to_string(muonstartpos.X()) + ", " + to_string(muonstartpos.Y()) + ", " + to_string(muonstartpos.Z()) +", "+to_string(muonstarttime)+ "\n"
-            + "           " +to_string(muondirection.X()) + ", " + to_string(muondirection.Y()) + ", " + to_string(muondirection.Z()) + ") " + "\n";
-  Log(logmessage,v_debug,verbosity);
-  return fMuonStartVertex;
-}
-
-void DigitBuilder::PushTrueVertex(bool savetodisk) {
-	Log("DigitBuilder Tool: Push true vertex to the RecoEvent store",v_message,verbosity);
-	m_data->Stores.at("RecoEvent")->Set("TrueVertex", fMuonStartVertex, savetodisk); 
-}
-
-// This function isn't working now, because the MRDTracks store must have been changed. 
-// We have to contact Marcus and ask how we can retieve the MRD track information. 
-bool DigitBuilder::EventSelectionByMRDReco() {
-  /// Get number of subentries
-	int NumMrdTracks = 0;
-	double mrdtracklength = 0.;
-	double MaximumMRDTrackLength = 0;
-	int mrdlayershit = 0;
-	bool mrdtrackisstoped = false;
-	int longesttrackEntryNumber = -9999;
-	
-	auto getmrdtracks = m_data->Stores.at("MRDTracks")->Get("NumMrdTracks",NumMrdTracks);
-	if(!getmrdtracks) {
-	  Log("DigitBuilder Tool: Error retrieving MRDTracks Store!",v_error,verbosity); 
-		return false;	
-	}
-	logmessage = "DigitBuilder Tool: Found " + to_string(NumMrdTracks) + " MRD tracks";
-	Log(logmessage,v_message,verbosity);
-	
-	// If mrd track isn't found
-	if(NumMrdTracks == 0) {
-	  Log("DigitBuilder Tool: Found no MRD Tracks",v_message,verbosity);
-	  return false;
-	}
-	// If mrd track is found
-	// MRD tracks are saved in the "MRDTracks" Store. Each entry is an MRD track
-
-	for(int entrynum=0; entrynum<NumMrdTracks; entrynum++) {
-		//m_data->Stores["MRDTracks"]->GetEntry(entrynum);
-	  m_data->Stores.at("MRDTracks")->Get("TrackLength",mrdtracklength);
-	  m_data->Stores.at("MRDTracks")->Get("LayersHit",mrdlayershit);
-	  if(MaximumMRDTrackLength<mrdtracklength) {
-	    MaximumMRDTrackLength = mrdtracklength;
-	    longesttrackEntryNumber = entrynum;
-	  }
-	}
-	// check if the longest track is stopped inside MRD
-	//m_data->Stores["MRDTracks"]->GetEntry(longesttrackEntryNumber);
-	m_data->Stores.at("MRDTracks")->Get("IsMrdStopped",mrdtrackisstoped);
-	if(!mrdtrackisstoped) return false;
-	return true;
-}
-
-bool DigitBuilder::EventSelectionByMCTruthInfo() {
-	if(!fMuonStartVertex) return false;
-		
-	double trueVtxX, trueVtxY, trueVtxZ;
-	Position vtxPos = fMuonStartVertex->GetPosition();
-	Direction vtxDir = fMuonStartVertex->GetDirection();
-	trueVtxX = vtxPos.X();
-  trueVtxY = vtxPos.Y();
-  trueVtxZ = vtxPos.Z();
-  
-  // fiducial volume cut
-  double tankradius = ANNIEGeometry::Instance()->GetCylRadius();	
-  double fidcutradius = 0.8 * tankradius;
-  double fidcuty = 50.;
-	double fidcutz = 0.;
-	if(trueVtxZ > fidcutz) return false;
-	if( (TMath::Sqrt(TMath::Power(trueVtxX, 2) + TMath::Power(trueVtxZ,2)) > fidcutradius) 
-		  || (TMath::Abs(trueVtxY) > fidcuty) 
-		  || (trueVtxZ > fidcutz) ){
-    return false;
-	}	 	
-	
-//	// mrd cut
-//	double muonStopX, muonStopY, muonStopZ;
-//	Position muonStopPos = fMuonStopVertex->GetPosition();
-//	muonStopX = muonStopPos.X();
-//	muonStopY = muonStopPos.Y();
-//	muonStopZ = muonStopPos.Z();
-//	
-//	// The following dimensions are inaccurate. We need to get these numbers from the geometry class
-//	double distanceBetweenTankAndMRD = 10.; // about 10 cm
-//	double mrdThicknessZ = 60.0;
-//	double mrdWidthX = 305.0;
-//	double mrdHeightY = 274.0;
-//	if(muonStopZ<tankradius + distanceBetweenTankAndMRD || muonStopZ>tankradius + distanceBetweenTankAndMRD + mrdThicknessZ
-//		|| muonStopX<-1.0*mrdWidthX/2 || muonStopX>mrdWidthX/2
-//		|| muonStopY<-1.0*mrdHeightY/2 || muonStopY>mrdHeightY/2) {
-//	  return false;	
-//	}
-	
-  return true;	
 }

--- a/UserTools/DigitBuilder/DigitBuilder.h
+++ b/UserTools/DigitBuilder/DigitBuilder.h
@@ -56,36 +56,6 @@ class DigitBuilder: public Tool {
  	/// Clear digit list
  	void Reset();
  	
- 	
- 	/// \brief Event selection by MRD reconstructed information
- 	///
- 	/// Loop over all the MRC tracks. Find the track with the longest track
- 	/// length. If the longest track is stoped inside the MRD, the event is 
- 	/// selected
- 	bool EventSelectionByMRDReco();
- 	
- 	/// \brief Event selection by fidicual volume
- 	///
- 	/// The selection is based on the true vertex position from MC. 
- 	/// If the true vertex is inside the fidicual volume, the event 
- 	/// is selected. 
- 	/// The 
- 	bool EventSelectionByMCTruthInfo();
- 	
- 	/// \brief Find true neutrino vertex
- 	///
- 	/// Loop over all MC particles and find the particle with highest energy. 
- 	/// This particle is the primary muon. The muon start position, time and 
- 	/// the muon direction are used to initise the true neutrino vertex 
- 	RecoVertex* FindTrueVertexFromMC();
- 	
- 	/// \brief Save true neutrino vertex
- 	///
- 	/// Push true neutrino vertex to "RecoVertex"
- 	/// \param[in] bool savetodisk: save object to disk if savetodisk=true
- 	void PushTrueVertex(bool savetodisk);
- 	
- 	/// \brief Clear reconstructed hits
   ///
   /// Fills the parameter name and appropriate parameter values into
   /// the parameter container, to be used in the fit
@@ -94,9 +64,6 @@ class DigitBuilder: public Tool {
   int verbosity=1;
 	std::string fInputfile;
 	unsigned long fNumEvents;
-	bool fMRDRecoCut = false;
-	bool fMCTruthCut = false;
-	bool fEventCutStatus = false;
 	
 	/// \brief contents of ANNIEEvent filled by LoadWCSim and LoadWCSimLAPPD
 	std::string fMCFile;
@@ -114,10 +81,6 @@ class DigitBuilder: public Tool {
 	std::map<ChannelKey,std::vector<Hit>>* fTDCData=nullptr;            ///< MRD & veto hits
 	TimeClass* fEventTime=nullptr;    ///< NDigits trigger time in ns from when the particles were generated
 	
-	RecoVertex* fMuonStartVertex = nullptr; 	 ///< true muon start vertex
-	RecoVertex* fMuonStopVertex = nullptr; 	 ///< true muon stop vertex
-	std::vector<MCParticle>* fMCParticles=nullptr;  ///< truth tracks
-	
 	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.
 	int v_error=0;
 	int v_warning=1;
@@ -125,6 +88,8 @@ class DigitBuilder: public Tool {
 	int v_debug=3;
 	std::string logmessage;
 	
+	///RecoEvent information
+	bool fEventCutStatus;
 	/// Reconstructed information
 	std::vector<RecoDigit>* fDigitList;				///< Reconstructed Hits including both LAPPD hits and PMT hits
 	

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -87,7 +87,9 @@ bool EventSelector::Execute(){
 
 
 bool EventSelector::Finalise(){
-
+  delete fMuonStartVertex;
+  delete fMuonStopVertex;
+  if(verbosity>0) cout<<"EventSelector exitting"<<endl;
   return true;
 }
 

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -1,0 +1,237 @@
+#include "EventSelector.h"
+
+EventSelector::EventSelector():Tool(){}
+
+
+bool EventSelector::Initialise(std::string configfile, DataModel &data){
+
+  /////////////////// Usefull header ///////////////////////
+  if(configfile!="")  m_variables.Initialise(configfile); //loading config file
+  //m_variables.Print();
+
+  m_data= &data; //assigning transient data pointer
+  /////////////////////////////////////////////////////////////////
+
+  //Get the tool configuration variables
+  m_variables.Get("verbosity",verbosity);
+  m_variables.Get("RunMRDRecoCut", fRunMRDRecoCut);
+  m_variables.Get("RunMCTruthCut", fRunMCTruthCut);
+
+  /// Construct the other objects we'll be setting at event level,
+  fMuonStartVertex = new RecoVertex();
+  fMuonStopVertex = new RecoVertex();
+  
+  // Make the RecoDigit Store if it doesn't exist
+  int recoeventexists = m_data->Stores.count("RecoEvent");
+  if(recoeventexists==0) m_data->Stores["RecoEvent"] = new BoostStore(false,2);
+  m_data->Stores.at("RecoEvent")->Set("EvtSelectionMask", fEvtSelectionMask); 
+  return true;
+}
+
+
+bool EventSelector::Execute(){
+  // Reset everything
+  this->Reset();
+  
+  // see if "ANNIEEvent" exists
+  auto get_annieevent = m_data->Stores.count("ANNIEEvent");
+  if(!get_annieevent){
+  	Log("EventSelector Tool: No ANNIEEvent store!",v_error,verbosity); 
+  	return false;
+  };
+
+	// Retrieve particle information from ANNIEEvent
+  auto get_mcparticles = m_data->Stores.at("ANNIEEvent")->Get("MCParticles",fMCParticles);
+	if(!get_mcparticles){ 
+		Log("EventSelector:: Tool: Error retrieving MCParticles from ANNIEEvent!",v_error,verbosity); 
+		return false; 
+	}
+	
+	/// check if "MRDTracks" store exists
+	int mrdtrackexists = m_data->Stores.count("MRDTracks");
+	if(mrdtrackexists == 0) {
+	  Log("EventSelector Tool: MRDTracks store doesn't exist!",v_message,verbosity);
+	  return false;
+	} 	
+	
+  /// Find true neutrino vertex which is defined by the start point of the Primary muon
+  this->FindTrueVertexFromMC();
+  fEventCutStatus = true;
+  if(fRunMCTruthCut){
+    bool passMCTruth= this->EventSelectionByMCTruthInfo();
+    if(!passMCTruth) fEventCutStatus = false; 
+  }
+  //FIXME: This isn't working according to Jingbo
+  if(fRunMRDRecoCut){
+    std::cout << "EventSelector Tool: Currently not implemented. Setting to false" << std::endl;
+    Log("EventSelector Tool: MRDReco not implemented.  Setting cut bit to false",v_message,verbosity);
+    bool passMRDRecoCut = false:
+    //bool passMRDRecoCut = this->EventSelectionByMRDReco(); 
+    if(!passMRDRecoCut) fEventCutStatus = false; 
+  //}
+  // Event selection successfully run
+  EventSelectionRan = true;
+  m_data->Stores.at("RecoEvent")->Set("EventCutStatus", fEventCutStatus);
+  return true;
+}
+
+
+bool EventSelector::Finalise(){
+
+  return true;
+}
+
+RecoVertex* EventSelector::FindTrueVertexFromMC() {
+  
+  // loop over the MCParticles to find the highest enery primary muon
+  // MCParticles is a std::vector<MCParticle>
+  MCParticle primarymuon;  // primary muon
+  bool mufound=false;
+  if(fMCParticles){
+    Log("EventSelector::  Tool: Num MCParticles = "+to_string(fMCParticles->size()),v_message,verbosity);
+    for(int particlei=0; particlei<fMCParticles->size(); particlei++){
+      MCParticle aparticle = fMCParticles->at(particlei);
+      //if(v_debug<verbosity) aparticle.Print();       // print if we're being *really* verbose
+      if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle
+      if(aparticle.GetPdgCode()!=13) continue;       // not a muon
+      primarymuon = aparticle;                       // note the particle
+      mufound=true;                                  // note that we found it
+      //primarymuon.Print();
+      break;                                         // won't have more than one primary muon
+    }
+  } else {
+    Log("EventSelector::  Tool: No MCParticles in the event!",v_error,verbosity);
+  }
+  if(not mufound){
+    Log("EventSelector::  Tool: No muon in this event",v_warning,verbosity);
+    return 0;
+  }
+  
+  // retrieve desired information from the particle
+  Position muonstartpos = primarymuon.GetStartVertex();    // only true if the muon is primary
+  double muonstarttime = primarymuon.GetStartTime().GetNs() + primarymuon.GetStopTime().GetTpsec()/1000;
+  Position muonstoppos = primarymuon.GetStopVertex();    // only true if the muon is primary
+  double muonstoptime = primarymuon.GetStopTime().GetNs() + primarymuon.GetStopTime().GetTpsec()/1000;
+  
+  Direction muondirection = primarymuon.GetStartDirection();
+  double muonenergy = primarymuon.GetStartEnergy();
+  // set true vertex
+  // change unit
+  muonstartpos.UnitToCentimeter(); // convert unit from meter to centimeter
+  muonstoppos.UnitToCentimeter(); // convert unit from meter to centimeter
+  // change coordinate for muon start vertex
+  muonstartpos.SetY(muonstartpos.Y()+14.46469);
+  muonstartpos.SetZ(muonstartpos.Z()-168.1);
+  fMuonStartVertex->SetVertex(muonstartpos, muonstarttime);
+  fMuonStartVertex->SetDirection(muondirection);
+  //  charge coordinate for muon stop vertex
+  muonstoppos.SetY(muonstoppos.Y()+14.46469);
+  muonstoppos.SetZ(muonstoppos.Z()-168.1);
+  fMuonStopVertex->SetVertex(muonstoppos, muonstoptime); 
+  
+  logmessage = "  trueVtx=(" +to_string(muonstartpos.X()) + ", " + to_string(muonstartpos.Y()) + ", " + to_string(muonstartpos.Z()) +", "+to_string(muonstarttime)+ "\n"
+            + "           " +to_string(muondirection.X()) + ", " + to_string(muondirection.Y()) + ", " + to_string(muondirection.Z()) + ") " + "\n";
+  Log(logmessage,v_debug,verbosity);
+  return fMuonStartVertex;
+}
+
+void EventSelector::PushTrueVertex(bool savetodisk) {
+  Log("EventSelector Tool: Push true vertex to the RecoEvent store",v_message,verbosity);
+  m_data->Stores.at("RecoEvent")->Set("TrueVertex", fMuonStartVertex, savetodisk); 
+}
+
+
+// This function isn't working now, because the MRDTracks store must have been changed. 
+// We have to contact Marcus and ask how we can retieve the MRD track information. 
+bool EventSelector::EventSelectionByMRDReco() {
+  /// Get number of subentries
+  int NumMrdTracks = 0;
+  double mrdtracklength = 0.;
+  double MaximumMRDTrackLength = 0;
+  int mrdlayershit = 0;
+  bool mrdtrackisstoped = false;
+  int longesttrackEntryNumber = -9999;
+  
+  auto getmrdtracks = m_data->Stores.at("MRDTracks")->Get("NumMrdTracks",NumMrdTracks);
+  if(!getmrdtracks) {
+    Log("EventSelector Tool: Error retrieving MRDTracks Store!",v_error,verbosity); 
+  	return false;	
+  }
+  logmessage = "EventSelector Tool: Found " + to_string(NumMrdTracks) + " MRD tracks";
+  Log(logmessage,v_message,verbosity);
+  
+  // If mrd track isn't found
+  if(NumMrdTracks == 0) {
+    Log("EventSelector Tool: Found no MRD Tracks",v_message,verbosity);
+    return false;
+  }
+  // If mrd track is found
+  // MRD tracks are saved in the "MRDTracks" Store. Each entry is an MRD track
+  
+  for(int entrynum=0; entrynum<NumMrdTracks; entrynum++) {
+    //m_data->Stores["MRDTracks"]->GetEntry(entrynum);
+    m_data->Stores.at("MRDTracks")->Get("TrackLength",mrdtracklength);
+    m_data->Stores.at("MRDTracks")->Get("LayersHit",mrdlayershit);
+    if(MaximumMRDTrackLength<mrdtracklength) {
+      MaximumMRDTrackLength = mrdtracklength;
+      longesttrackEntryNumber = entrynum;
+    }
+  }
+  // check if the longest track is stopped inside MRD
+  //m_data->Stores["MRDTracks"]->GetEntry(longesttrackEntryNumber);
+  m_data->Stores.at("MRDTracks")->Get("IsMrdStopped",mrdtrackisstoped);
+  if(!mrdtrackisstoped) return false;
+  return true;
+}
+
+
+bool EventSelector::EventSelectionByMCTruthInfo() {
+  if(!fMuonStartVertex) return false;
+  
+  double trueVtxX, trueVtxY, trueVtxZ;
+  Position vtxPos = fMuonStartVertex->GetPosition();
+  Direction vtxDir = fMuonStartVertex->GetDirection();
+  trueVtxX = vtxPos.X();
+  trueVtxY = vtxPos.Y();
+  trueVtxZ = vtxPos.Z();
+  
+  // fiducial volume cut
+  double tankradius = ANNIEGeometry::Instance()->GetCylRadius();	
+  double fidcutradius = 0.8 * tankradius;
+  double fidcuty = 50.;
+  double fidcutz = 0.;
+  if(trueVtxZ > fidcutz) return false;
+  if( (TMath::Sqrt(TMath::Power(trueVtxX, 2) + TMath::Power(trueVtxZ,2)) > fidcutradius) 
+  	  || (TMath::Abs(trueVtxY) > fidcuty) 
+  	  || (trueVtxZ > fidcutz) ){
+  return false;
+  }	 	
+  
+//	// mrd cut
+//	double muonStopX, muonStopY, muonStopZ;
+//	Position muonStopPos = fMuonStopVertex->GetPosition();
+//	muonStopX = muonStopPos.X();
+//	muonStopY = muonStopPos.Y();
+//	muonStopZ = muonStopPos.Z();
+//	
+//	// The following dimensions are inaccurate. We need to get these numbers from the geometry class
+//	double distanceBetweenTankAndMRD = 10.; // about 10 cm
+//	double mrdThicknessZ = 60.0;
+//	double mrdWidthX = 305.0;
+//	double mrdHeightY = 274.0;
+//	if(muonStopZ<tankradius + distanceBetweenTankAndMRD || muonStopZ>tankradius + distanceBetweenTankAndMRD + mrdThicknessZ
+//		|| muonStopX<-1.0*mrdWidthX/2 || muonStopX>mrdWidthX/2
+//		|| muonStopY<-1.0*mrdHeightY/2 || muonStopY>mrdHeightY/2) {
+//	  return false;	
+//	}
+	
+  return true;	
+}
+
+void EventSelector::Reset() {
+  // Reset 
+  fMuonStartVertex->Reset();
+  fMuonStopVertex->Reset();
+  fEventSelectionRan = false;
+  m_data->Stores.at("RecoEvent")->Set("EventSelectionRan", fEventSelectionRan);
+} 

--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -71,10 +71,9 @@ class EventSelector: public Tool {
 
 	std::string fInputfile;
 	unsigned long fNumEvents;
-	bool fRunMRDRecoCut = false;
-	bool fRunMCTruthCut = false;
+	bool fMRDRecoCut = false;
+	bool fMCTruthCut = false;
 	bool fEventCutStatus;
-	bool fEventSelectionRan;
 
 	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.
 	int v_error=0;

--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -1,0 +1,89 @@
+//This tool reads information from both the Monte Carlo and
+//Event reconstruction and flags each event with the
+//chosen flags in the EventSelector config file.
+
+#ifndef EventSelector_H
+#define EventSelector_H
+
+#include <string>
+#include <iostream>
+#include <TROOT.h>
+#include <TChain.h>
+#include <TFile.h>
+
+#include "Tool.h"
+// ROOT includes
+#include "TFile.h"
+#include "TTree.h"
+#include "ANNIEGeometry.h"
+
+class EventSelector: public Tool {
+
+
+ public:
+
+  EventSelector();
+  bool Initialise(std::string configfile,DataModel &data);
+  bool Execute();
+  bool Finalise();
+
+
+ private:
+ 	
+	/// Clear reconstruction info.
+ 	void Reset();
+
+ 	/// \brief Event selection by MRD reconstructed information
+ 	///
+ 	/// Loop over all the MRC tracks. Find the track with the longest track
+ 	/// length. If the longest track is stoped inside the MRD, the event is 
+ 	/// selected
+ 	bool EventSelectionByMRDReco();
+ 	
+ 	/// \brief Event selection by fidicual volume
+ 	///
+ 	/// The selection is based on the true vertex position from MC. 
+ 	/// If the true vertex is inside the fidicual volume, the event 
+ 	/// is selected. 
+ 	/// The 
+ 	bool EventSelectionByMCTruthInfo();
+ 	
+ 	/// \brief Find true neutrino vertex
+ 	///
+ 	/// Loop over all MC particles and find the particle with highest energy. 
+ 	/// This particle is the primary muon. The muon start position, time and 
+ 	/// the muon direction are used to initise the true neutrino vertex 
+ 	RecoVertex* FindTrueVertexFromMC();
+ 	
+ 	/// \brief Save true neutrino vertex
+ 	///
+ 	/// Push true neutrino vertex to "RecoVertex"
+ 	/// \param[in] bool savetodisk: save object to disk if savetodisk=true
+ 	void PushTrueVertex(bool savetodisk);
+
+	Geometry fGeometry;    ///< ANNIE Geometry
+	RecoVertex* fMuonStartVertex = nullptr; 	 ///< true muon start vertex
+	RecoVertex* fMuonStopVertex = nullptr; 	 ///< true muon stop vertex
+	std::vector<MCParticle>* fMCParticles=nullptr;  ///< truth tracks
+
+	//verbosity initialization
+	int verbosity=1;
+
+	std::string fInputfile;
+	unsigned long fNumEvents;
+	bool fRunMRDRecoCut = false;
+	bool fRunMCTruthCut = false;
+	bool fEventCutStatus;
+	bool fEventSelectionRan;
+
+	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.
+	int v_error=0;
+	int v_warning=1;
+	int v_message=2;
+	int v_debug=3;
+	std::string logmessage;
+
+};
+
+
+#endif

--- a/UserTools/EventSelector/README.md
+++ b/UserTools/EventSelector/README.md
@@ -7,14 +7,25 @@ EventSelector
 The event selector tool flags events in the input data file as passing or failing
 various event selection criteria.  Current event selection flags that can be
 utilized include:
-  - FV: Flags muon events that reconstruct within a defined radius and height
+  - MRDRecoCut Flags muon events that reconstruct within a defined radius and height
+  - MCTruthCut: Flags MC muon events generated within a defined radius and height 
 
+For each event, all cuts defined with the config file are checked.  If the event
+passes all cuts, EventCutStatus is set to true and saved to the RecoEvent store.
+If any cut fails, EventCutStatus is set to false.
+
+Eventually, this tool will also add a bit mask to the RecoEvent store telling which
+Cuts were checked when the EventSelector tool was run.  The bitmask will have bits
+filled as defined below in the configuration (first cut defined -> least
+significant bit). 
 
 ## Configuration
 
-Describe any configuration variables for EventSelector.
+Configurables tell EventSelector which cuts to run/check when defining the
+master EventCutStatus bit checked by all following tools
 
 ```
-param1 value1
-param2 value2
+verbosity bool
+MRDRecoCut (1 or 0)
+MCTruthCut (1 or 0)
 ```

--- a/UserTools/EventSelector/README.md
+++ b/UserTools/EventSelector/README.md
@@ -1,0 +1,20 @@
+# EventSelector
+
+EventSelector
+
+## Data
+
+The event selector tool flags events in the input data file as passing or failing
+various event selection criteria.  Current event selection flags that can be
+utilized include:
+  - FV: Flags muon events that reconstruct within a defined radius and height
+
+
+## Configuration
+
+Describe any configuration variables for EventSelector.
+
+```
+param1 value1
+param2 value2
+```

--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -54,6 +54,7 @@ if (tool=="LAPPDAnalysis") ret=new LAPPDAnalysis;
 if (tool=="ExampleOverTool") ret=new ExampleOverTool;
 if (tool=="PhaseIITreeMaker") ret=new PhaseIITreeMaker;
 if (tool=="VertexGeometryCheck") ret=new VertexGeometryCheck;
-  if (tool=="LikelihoodFitterCheck") ret=new LikelihoodFitterCheck;
+if (tool=="LikelihoodFitterCheck") ret=new LikelihoodFitterCheck;
+  if (tool=="EventSelector") ret=new EventSelector;
 return ret;
 }

--- a/UserTools/Unity.cpp
+++ b/UserTools/Unity.cpp
@@ -59,3 +59,4 @@
 #include "PhaseIITreeMaker/PhaseIITreeMaker.cpp"
 #include "VertexGeometryCheck/VertexGeometryCheck.cpp"
 #include "LikelihoodFitterCheck/LikelihoodFitterCheck.cpp"
+#include "EventSelector/EventSelector.cpp"

--- a/configfiles/PhaseIIReco/EventSelectorConfig
+++ b/configfiles/PhaseIIReco/EventSelectorConfig
@@ -1,0 +1,4 @@
+# EventSelector config file
+
+MCTruthCut 1
+MRDRecoCut 0

--- a/configfiles/PhaseIIReco/ToolsConfig
+++ b/configfiles/PhaseIIReco/ToolsConfig
@@ -1,6 +1,7 @@
 LoadWCSim LoadWCSim ./configfiles/PhaseIIReco/LoadWCSimConfig
 LoadWCSimLAPPD LoadWCSimLAPPD ./configfiles/PhaseIIReco/LoadWCSimLAPPDConfig
 FindMrdTracks FindMrdTracks ./configfiles/FindMrdTracks/FindMrdTracksConfig
+EventSelector EventSelector ./configfiles/PhaseIIReco/EventSelectorConfig
 DigitBuilder DigitBuilder ./configfiles/PhaseIIReco/DigitBuilderConfig
 VtxSeedGenerator VtxSeedGenerator ./configfiles/PhaseIIReco/VtxSeedGeneratorConfig
 VtxPointPositionFinder VtxPointPositionFinder ./configfiles/PhaseIIReco/VtxPointPositionFinderConfig

--- a/configfiles/PhaseIISanityCheck/EventSelectorConfig
+++ b/configfiles/PhaseIISanityCheck/EventSelectorConfig
@@ -1,0 +1,4 @@
+# EventSelector config file
+verbosity 3
+MCTruthCut 1
+MRDRecoCut 0

--- a/configfiles/PhaseIISanityCheck/ToolsConfig
+++ b/configfiles/PhaseIISanityCheck/ToolsConfig
@@ -1,6 +1,7 @@
 LoadWCSim LoadWCSim ./configfiles/PhaseIISanityCheck/LoadWCSimConfig
 LoadWCSimLAPPD LoadWCSimLAPPD ./configfiles/PhaseIISanityCheck/LoadWCSimLAPPDConfig
 FindMrdTracks FindMrdTracks ./configfiles/FindMrdTracks/FindMrdTracksConfig
+EventSelector EventSelector ./configfiles/PhaseIISanityCheck/EventSelectorConfig
 DigitBuilder DigitBuilder ./configfiles/PhaseIISanityCheck/DigitBuilderConfig
 VtxSeedGenerator VtxSeedGenerator ./configfiles/PhaseIISanityCheck/VtxSeedGeneratorConfig
 VertexGeometryCheck VertexGeometryCheck ./configfiles/PhaseIISanityCheck/VertexGeometryCheckConfig


### PR DESCRIPTION
Implemented the EventSelector tool, which holds functions used to determine if reconstruction should be executed for events.  This pull request pulls the functions that were originally doing this inside DigitBuilder and implements them in a separate tool format.