### PR TITLE
PointPositionFinder results now saved to PhaseIITreeMaker

### DIFF
--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -35,6 +35,11 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   fRecoTree->Branch("trueDirX",&fTrueDirX,"trueDirX/D");
   fRecoTree->Branch("trueDirY",&fTrueDirY,"trueDirY/D");
   fRecoTree->Branch("trueDirZ",&fTrueDirZ,"trueDirZ/D");
+  fRecoTree->Branch("pointPosVtxX",&fPointPosVtxX,"pointPosVtxX/D");
+  fRecoTree->Branch("pointPosVtxY",&fPointPosVtxY,"pointPosVtxY/D");
+  fRecoTree->Branch("pointPosVtxZ",&fPointPosVtxZ,"pointPosVtxZ/D");
+  fRecoTree->Branch("pointPosVtxTime",&fPointPosVtxTime,"pointPosVtxTime/D");
+  fRecoTree->Branch("pointPosVtxStatus",&fPointPosVtxStatus,"pointPosVtxStatus/I");
   fRecoTree->Branch("seedVtxX",&fSeedVtxX); 
   fRecoTree->Branch("seedVtxY",&fSeedVtxY); 
   fRecoTree->Branch("seedVtxZ",&fSeedVtxZ); 
@@ -109,6 +114,16 @@ bool PhaseIITreeMaker::Execute(){
   fTrueDirX = truevtx->GetDirection().X();
   fTrueDirY = truevtx->GetDirection().Y();
   fTrueDirZ = truevtx->GetDirection().Z();
+
+  // Read PointPosition-fitted Vertex   
+  RecoVertex* pointposvtx = 0;
+  m_data->Stores.at("RecoEvent")->Get("PointPosition",pointposvtx); 
+  
+  fPointPosVtxX = pointposvtx->GetPosition().X();
+  fPointPosVtxY = pointposvtx->GetPosition().Y();
+  fPointPosVtxZ = pointposvtx->GetPosition().Z();
+  fPointPosVtxTime = pointposvtx->GetTime();
+  fPointPosVtxStatus = pointposvtx->GetStatus();
   
   // Read Seed Vertex   
   std::vector<RecoVertex>* seedvtxlist = 0;
@@ -122,6 +137,7 @@ bool PhaseIITreeMaker::Execute(){
     fSeedVtxY.push_back(seed.GetPosition().Y());
     fSeedVtxZ.push_back(seed.GetPosition().Z());
   }
+
   
   // Read digits
   std::vector<RecoDigit>* digitList = nullptr;
@@ -176,9 +192,15 @@ void PhaseIITreeMaker::ResetVariables() {
   fTrueDirX = 0;
   fTrueDirY = 0;
   fTrueDirZ = 0;
+  fPointPosVtxX = 0;
+  fPointPosVtxY = 0;
+  fPointPosVtxZ = 0;
+  fPointPosVtxTime = 0;
+  fPointPosVtxStatus = 0;
   fRecoVtxX = 0;
   fRecoVtxY = 0;
   fRecoVtxZ = 0;
+  fRecoStatus = 0;
   fRecoVtxTime = 0;
   fRecoDirX = 0;
   fRecoDirY = 0;

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -117,25 +117,28 @@ bool PhaseIITreeMaker::Execute(){
 
   // Read PointPosition-fitted Vertex   
   RecoVertex* pointposvtx = 0;
-  m_data->Stores.at("RecoEvent")->Get("PointPosition",pointposvtx); 
-  
-  fPointPosVtxX = pointposvtx->GetPosition().X();
-  fPointPosVtxY = pointposvtx->GetPosition().Y();
-  fPointPosVtxZ = pointposvtx->GetPosition().Z();
-  fPointPosVtxTime = pointposvtx->GetTime();
-  fPointPosVtxStatus = pointposvtx->GetStatus();
-  
+  auto get_pointposdata = m_data->Stores.at("RecoEvent")->Get("PointPosition",pointposvtx);
+  if(get_pointposdata){ 
+    fPointPosVtxX = pointposvtx->GetPosition().X();
+    fPointPosVtxY = pointposvtx->GetPosition().Y();
+    fPointPosVtxZ = pointposvtx->GetPosition().Z();
+    fPointPosVtxTime = pointposvtx->GetTime();
+    fPointPosVtxStatus = pointposvtx->GetStatus();
+  } else{
+    Log("PhaseIITreeMaker Tool: No PointPosition data found.  Continuing to build remaining tree",v_message,verbosity);
+  }
+ 
   // Read Seed Vertex   
   std::vector<RecoVertex>* seedvtxlist = 0;
   auto get_seedvtxlist = m_data->Stores.at("RecoEvent")->Get("vSeedVtxList",seedvtxlist);  ///> Get List of seeds from "RecoEvent" 
-  if(!get_seedvtxlist){ 
-  	Log("PhaseIITreeMaker  Tool: Error retrieving Seed List! ",v_error,verbosity); 
-  	return true;
-  }
- for( auto& seed : *seedvtxlist ){
-    fSeedVtxX.push_back(seed.GetPosition().X());
-    fSeedVtxY.push_back(seed.GetPosition().Y());
-    fSeedVtxZ.push_back(seed.GetPosition().Z());
+  if(get_seedvtxlist){
+    for( auto& seed : *seedvtxlist ){
+      fSeedVtxX.push_back(seed.GetPosition().X());
+      fSeedVtxY.push_back(seed.GetPosition().Y());
+      fSeedVtxZ.push_back(seed.GetPosition().Z());
+    }
+  } else {  
+	Log("PhaseIITreeMaker  Tool: No Seed List found.  Continuing to build tree ",v_message,verbosity); 
   }
 
   

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -69,8 +69,16 @@ class PhaseIITreeMaker: public Tool {
   std::vector<double> fSeedVtxX;
   std::vector<double> fSeedVtxY;
   std::vector<double> fSeedVtxZ;
-  
+
   // Reco vertex
+  // Point Position Vertex
+  double fPointPosVtxX;
+  double fPointPosVtxY;
+  double fPointPosVtxZ;
+  double fPointPosVtxTime;
+  int fPointPosVtxStatus;
+  
+
   // Vertex
   double fRecoVtxX;
   double fRecoVtxY;


### PR DESCRIPTION
If ran, the Point Position finder's best fit vertex is now output by PhaseIITreeMaker.

Also, PhaseIITreeMaker has been modified so that it will continue to fill trees even if an event did not have the SeedGenerator or VtxPointPositionFinder used.  If not run, entries associated with these tools will be filled as zeros in the tree.